### PR TITLE
Unit test adjustments for Darwin.

### DIFF
--- a/psl-core/src/test/java/org/linqs/psl/application/learning/weight/bayesian/GaussianProcessPriorTest.java
+++ b/psl-core/src/test/java/org/linqs/psl/application/learning/weight/bayesian/GaussianProcessPriorTest.java
@@ -104,8 +104,8 @@ public class GaussianProcessPriorTest extends WeightLearningTest {
         wl.setBlasYKnownForTest(blasYKnown);
 
         GaussianProcessPrior.ValueAndStd fnAndStd = wl.predictFnValAndStd(x, xKnown);
-        Assert.assertEquals(0.84939, fnAndStd.value, 1e-5);
-        Assert.assertEquals(0.99656, fnAndStd.std, 1e-5);
+        Assert.assertEquals(0.84939, fnAndStd.value, 1e-4);
+        Assert.assertEquals(0.99656, fnAndStd.std, 1e-4);
     }
 
     @Test

--- a/psl-core/src/test/java/org/linqs/psl/util/FloatMatrixTest.java
+++ b/psl-core/src/test/java/org/linqs/psl/util/FloatMatrixTest.java
@@ -393,7 +393,7 @@ public class FloatMatrixTest {
         }
 
         try {
-            matrix = new FloatMatrix(new float[][]{{-1.0f, 1.5f}, {(2.0f / 3.0f), -1.0f}});
+            matrix = new FloatMatrix(new float[][]{{-1.0f, 2.0f}, {0.5f, -1.0f}});
             inverse = matrix.inverse();
             fail("Did not throw an exception on trying to invert a non-invertable matrix.");
         } catch (ArithmeticException ex) {


### PR DESCRIPTION
Due to difference in floating point calculations between OSs, some of the unit tests fail. See logs below. This commit accomodates UTs for Mac.

See logs:
Failed tests:
  GaussianProcessPriorTest.testPredictFnValAndStd:107 expected:<0.84939> but was:<0.849437952041626>
  FloatMatrixTest.testInversion:399 Did not throw an exception on trying to invert a non-invertable matrix.